### PR TITLE
Fix bug where app would crash before playing the game

### DIFF
--- a/PullToRefreshDemo/BreakOutToRefreshView.swift
+++ b/PullToRefreshDemo/BreakOutToRefreshView.swift
@@ -337,8 +337,8 @@ class BreakOutScene: SKScene, SKPhysicsContactDelegate {
   }
   
   func updateLabel(text: String) {
-    let label = childNodeWithName(backgroundLabelName) as! SKLabelNode
-    label.text = text
+    let label : SKLabelNode! = childNodeWithName(backgroundLabelName) as? SKLabelNode;
+    label?.text = text
   }
   
   func moveHandle(value: CGFloat) {

--- a/PullToRefreshDemo/BreakOutToRefreshView.swift
+++ b/PullToRefreshDemo/BreakOutToRefreshView.swift
@@ -79,7 +79,6 @@ class BreakOutToRefreshView: SKView {
     blockColors = [UIColor.whiteColor()]
     
     super.init(frame: frame)
-    
   }
   
   

--- a/PullToRefreshDemo/BreakOutToRefreshView.swift
+++ b/PullToRefreshDemo/BreakOutToRefreshView.swift
@@ -79,6 +79,7 @@ class BreakOutToRefreshView: SKView {
     blockColors = [UIColor.whiteColor()]
     
     super.init(frame: frame)
+
   }
   
   


### PR DESCRIPTION
If the user tries to scroll down before playing the game for the first time, updateLabel would try and unwrap an Optional and fail, because it can't find the appropriate SKSpriteNode.
